### PR TITLE
Fix the configuration of Doc building tools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,11 +41,11 @@ AC_ARG_ENABLE(debug,
 
 dnl ############## Check for tools to build documentation
 
-AC_PATH_PROG( [ASCIIDOC], [asciidoc] )
-AC_SUBST( POD2MAN )
+AC_PATH_PROG( [ASCIIDOC], [asciidoctor] )
+AC_SUBST(ASCIIDOC)
 
 AC_PATH_PROG( [XMLTO], [xmlto] )
-AC_SUBST( XMLTO )
+AC_SUBST(XMLTO)
 
 if test "x$ac_cv_path_ASCIIDOC" != "x" -a "x$ac_cv_path_XMLTO" != "x"; then
 	BUILD_DOC="Yes"


### PR DESCRIPTION
autoconf has become stricter about whitespace, therefore isn't
accepting the AC_SUBST clauses any more.
While at it replace asciidoc by asciidoctor, the contemporary
variant of this tool.

Signed-off-by: Jaap Keuter <jaap.keuter@xs4all.nl>