### PR TITLE
Remove lingering ident string

### DIFF
--- a/libgsm/gsm_create.c
+++ b/libgsm/gsm_create.c
@@ -4,7 +4,7 @@
  * details.  THERE IS ABSOLUTELY NO WARRANTY FOR THIS SOFTWARE.
  */
 
-static char const	ident[] = "$Header: /tmp_amd/presto/export/kbs/jutta/src/gsm/RCS/gsm_create.c,v 1.4 1996/07/02 09:59:05 jutta Exp $";
+/* $Header: /tmp_amd/presto/export/kbs/jutta/src/gsm/RCS/gsm_create.c,v 1.4 1996/07/02 09:59:05 jutta Exp $ */
 
 #include	"config.h"
 


### PR DESCRIPTION
A lingering ident string, which is not used in the build,
causes the build to fail. Other ident strings have been
wrapped in comments, this one should be too.

Signed-off-by: Jaap Keuter <jaap.keuter@xs4all.nl>