### PR TITLE
Remove include of samplerate header file

### DIFF
--- a/src/MastCodec.h
+++ b/src/MastCodec.h
@@ -21,7 +21,6 @@
 #ifndef	_MAST_CODEC_H_
 #define	_MAST_CODEC_H_
 
-#include <samplerate.h>
 #include "MastAudioBuffer.h"
 #include "MastMimeType.h"
 #include "mast.h"


### PR DESCRIPTION
Including the samplerate header file serves no purpose here:
its types are not used in this header file, and
the source files that need it include it anyway.
What it does cause is a hard dependancy of libsamplerate,
which configure.ac states as being optional.

Signed-off-by: Jaap Keuter <jaap.keuter@xs4all.nl>