### PR TITLE
Constify format string

### DIFF
--- a/src/mast.h
+++ b/src/mast.h
@@ -106,7 +106,7 @@ extern PayloadType payload_type_mpeg_audio;
 
 
 // ------- util.cpp -------
-void mast_message_handler( int level, const char* file, int line, char *fmt, ... );
+void mast_message_handler( int level, const char* file, int line, const char *fmt, ... );
 int mast_still_running();
 void mast_stop_running();
 void mast_setup_signals();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -92,7 +92,7 @@ void mast_setup_signals()
 
 
 /* Handle an error and store the error message */
-void mast_message_handler( int level, const char* file, int line, char *fmt, ... )
+void mast_message_handler( int level, const char* file, int line, const char *fmt, ... )
 {
 	va_list args;
 	char lastchar = fmt[ strlen(fmt)-1 ];


### PR DESCRIPTION
The format string needs to be declared const, otherwise
the GCC compiler will complain, causing a build error.

Signed-off-by: Jaap Keuter <jaap.keuter@xs4all.nl>