### PR TITLE
Adapt to new ortp

### DIFF
--- a/src/MastTool.cpp
+++ b/src/MastTool.cpp
@@ -390,7 +390,7 @@ void MastTool::set_session_address( const char* in_addr )
 	if (this->session->mode == RTP_SESSION_RECVONLY) {
 	
 		// Set the local address/port
-		if (rtp_session_set_local_addr( session, address, port )) {
+		if (rtp_session_set_local_addr( session, address, port, port + 1 )) {
 			MAST_FATAL("Failed to set local address/port (%s/%d)", address, port);
 		} else {
 			MAST_INFO( "Local address: %s/%d", address,  port );

--- a/src/mast_info.cpp
+++ b/src/mast_info.cpp
@@ -89,7 +89,7 @@ static void parse_cmd_line(int argc, char **argv, RtpSession* session)
 	if (local_port%2 == 1) local_port--;
 	
 	// Set the remote address/port
-	if (rtp_session_set_local_addr( session, local_address, local_port )) {
+	if (rtp_session_set_local_addr( session, local_address, local_port, local_port + 1 )) {
 		MAST_FATAL("Failed to set receive address/port (%s/%u)", local_address, local_port);
 	} else {
 		printf( "Receive address: %s/%u\n", local_address,  local_port );

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -37,6 +37,8 @@
 /* Globals */
 static int g_mast_running = TRUE;
 
+static char mpeg_audio_mime_type[] = "mpa";
+
 // RTP Payload Type for MPEG Audio
 PayloadType	payload_type_mpeg_audio = {
 	PAYLOAD_AUDIO_PACKETIZED, // type
@@ -45,8 +47,12 @@ PayloadType	payload_type_mpeg_audio = {
 	NULL,	// zero pattern N/A
 	0,		// pattern_length N/A
 	0,		// normal_bitrate
-	"mpa",	// MIME Type
-	0		// flags
+	mpeg_audio_mime_type, // MIME Type
+	1,		// channels
+	NULL,	// various format parameters for the incoming stream
+	NULL,	// various format parameters for the outgoing stream
+	0,		// flags
+	NULL	// user data
 };
 
 


### PR DESCRIPTION
The oRTP library (currently 3.6.1) has had some changes to
its API, which require adaptation of the API using code.

Signed-off-by: Jaap Keuter <jaap.keuter@xs4all.nl>