### PR TITLE
Add handler for channels parameter to L16 codec

### DIFF
--- a/src/MastCodec_L16.cpp
+++ b/src/MastCodec_L16.cpp
@@ -31,6 +31,19 @@
 #define	L16_DEFAULT_SAMPLERATE		(44100)
 #define	L16_DEFAULT_CHANNELS		(2)
 
+int MastCodec_L16::set_param_internal( const char* name, const char* value )
+{
+	if (strcmp(name, "channels")==0) {
+		int channels = atoi(value);
+		if ((channels < 0) || (channels > 2)) return -2;
+		this->channels = channels;
+	} else {
+		// Unsupported parameter
+		return -1;
+	}
+
+	return 0;
+}
 
 // Calculate the number of samples per packet
 size_t MastCodec_L16::frames_per_packet_internal( size_t max_bytes )

--- a/src/MastCodec_L16.h
+++ b/src/MastCodec_L16.h
@@ -35,6 +35,9 @@ public:
 
 protected:
 
+	// Set a codec parameter - returns 0 on success, or error number on failure
+	virtual int set_param_internal( const char* name, const char* value );
+
 	// Internal: encode a packet of audio - returns number of bytes encoded, or -1 on failure
 	virtual size_t encode_packet_internal( size_t num_frames, mast_sample_t *input, size_t out_size, u_int8_t *output );
 	


### PR DESCRIPTION
The L16 RTP stream can be monaural is the channels parameter
can be set to 1. The codec base class provides for this
parameter handler, but it needs to be implemented in the codec.
This change adds this handler to the L16 codec.

Signed-off-by: Jaap Keuter <jaap.keuter@xs4all.nl>